### PR TITLE
List Binder

### DIFF
--- a/.tests/extensions/listBinding/TestListBinder.cs
+++ b/.tests/extensions/listBinding/TestListBinder.cs
@@ -83,7 +83,7 @@ namespace strange.unittests
 
             Assert.AreNotEqual(list1, list2);
 
-            // Singleton
+            // Bound by value
             Assert.AreEqual(list1[0], list2[0]);
 
             // New instance

--- a/.tests/extensions/listBinding/TestListBinder.cs
+++ b/.tests/extensions/listBinding/TestListBinder.cs
@@ -10,7 +10,7 @@ namespace strange.unittests
     public class TestListBinder
     {
         private MockContext context;
-        IListBinder binder;
+        private IListBinder binder;
         private object contextView;
 
         [SetUp]
@@ -31,7 +31,7 @@ namespace strange.unittests
             binder.Bind<string>().ToValue("b");
             binder.Bind<string>().ToValue("c");
 
-            var strings = context.injectionBinder.GetInstance<List<string>>();
+            var strings = context.injectionBinder.GetInstance<IList<string>>();
 
             Assert.AreEqual(3, strings.Count);
             Assert.AreEqual("a", strings[0]);
@@ -40,12 +40,26 @@ namespace strange.unittests
         }
 
         [Test]
+        public void TestInjectListWithDuplicateValues()
+        {
+            binder.Bind<string>().ToValue("a");
+            binder.Bind<string>().ToValue("b");
+            binder.Bind<string>().ToValue("a");
+
+            var strings = context.injectionBinder.GetInstance<IList<string>>();
+
+            Assert.AreEqual(3, strings.Count);
+            Assert.AreEqual(strings[0], strings[2]);
+        }
+
+
+        [Test]
         public void TestInjectTypesToList()
         {
             binder.Bind<IListItem>().To<ListItemA>();
             binder.Bind<IListItem>().To<ListItemB>();
 
-            var list = context.injectionBinder.GetInstance<List<IListItem>>();
+            var list = context.injectionBinder.GetInstance<IList<IListItem>>();
 
             Assert.AreEqual(2, list.Count);
             Assert.IsAssignableFrom(typeof(ListItemA), list[0]);
@@ -59,8 +73,8 @@ namespace strange.unittests
             binder.Bind<IListItem>().To<ListItemA>().ToSingleton();
             binder.Bind<IListItem>().To<ListItemB>();
 
-            var list1 = context.injectionBinder.GetInstance<List<IListItem>>();
-            var list2 = context.injectionBinder.GetInstance<List<IListItem>>();
+            var list1 = context.injectionBinder.GetInstance<IList<IListItem>>();
+            var list2 = context.injectionBinder.GetInstance<IList<IListItem>>();
 
             Assert.AreNotEqual(list1, list2);
 
@@ -78,8 +92,8 @@ namespace strange.unittests
             binder.Bind<IListItem>().ToValue(new ListItemA());
             binder.Bind<IListItem>().To<ListItemB>();
 
-            var list1 = context.injectionBinder.GetInstance<List<IListItem>>();
-            var list2 = context.injectionBinder.GetInstance<List<IListItem>>();
+            var list1 = context.injectionBinder.GetInstance<IList<IListItem>>();
+            var list2 = context.injectionBinder.GetInstance<IList<IListItem>>();
 
             Assert.AreNotEqual(list1, list2);
 
@@ -89,6 +103,23 @@ namespace strange.unittests
             // New instance
             Assert.AreNotEqual(list1[1], list2[1]);
 
+        }
+
+        [TestCase]
+        public void TestInjectListAsSingleton()
+        {
+            binder.Bind<IListItem>().ToSingleton();
+            binder.Bind<IListItem>().ToValue(new ListItemA());
+            binder.Bind<IListItem>().To<ListItemB>();
+
+            var list1 = context.injectionBinder.GetInstance<IList<IListItem>>();
+            var list2 = context.injectionBinder.GetInstance<IList<IListItem>>();
+
+            // No matter how list items were bound they are all equal between 
+            // list1 and list2 because the list itself is bound as a singleton
+            Assert.AreEqual(list1, list2);
+            Assert.AreEqual(list1[0], list2[0]);
+            Assert.AreEqual(list1[1], list2[1]);
         }
     }
 

--- a/.tests/extensions/listBinding/TestListBinder.cs
+++ b/.tests/extensions/listBinding/TestListBinder.cs
@@ -1,0 +1,108 @@
+﻿using NUnit.Framework;
+using strange.extensions.context.impl;
+using strange.extensions.listBind.api;
+using strange.extensions.listBind.impl;
+using System.Collections.Generic;
+
+namespace strange.unittests
+{
+    [TestFixture]
+    public class TestListBinder
+    {
+        private MockContext context;
+        IListBinder binder;
+        private object contextView;
+
+        [SetUp]
+        public void SetUp()
+        {
+            Context.firstContext = null;
+            contextView = new object();
+            context = new MockContext(contextView, true);
+            context.Start();
+            binder = context.listBinder;
+
+        }
+
+        [Test]
+        public void TestInjectListWithValues()
+        {
+            binder.Bind<string>().ToValue("a");
+            binder.Bind<string>().ToValue("b");
+            binder.Bind<string>().ToValue("c");
+
+            var strings = context.injectionBinder.GetInstance<List<string>>();
+
+            Assert.AreEqual(3, strings.Count);
+            Assert.AreEqual("a", strings[0]);
+            Assert.AreEqual("b", strings[1]);
+            Assert.AreEqual("c", strings[2]);
+        }
+
+        [Test]
+        public void TestInjectTypesToList()
+        {
+            binder.Bind<IListItem>().To<ListItemA>();
+            binder.Bind<IListItem>().To<ListItemB>();
+
+            var list = context.injectionBinder.GetInstance<List<IListItem>>();
+
+            Assert.AreEqual(2, list.Count);
+            Assert.IsAssignableFrom(typeof(ListItemA), list[0]);
+            Assert.IsAssignableFrom(typeof(ListItemB), list[1]);
+        }
+
+
+        [Test]
+        public void TestInjectListWithSingletonItems()
+        {
+            binder.Bind<IListItem>().To<ListItemA>().ToSingleton();
+            binder.Bind<IListItem>().To<ListItemB>();
+
+            var list1 = context.injectionBinder.GetInstance<List<IListItem>>();
+            var list2 = context.injectionBinder.GetInstance<List<IListItem>>();
+
+            Assert.AreNotEqual(list1, list2);
+
+            // Singleton
+            Assert.AreEqual(list1[0], list2[0]);
+
+            // New instance
+            Assert.AreNotEqual(list1[1], list2[1]);
+
+        }
+
+        [Test]
+        public void TestInjectListWithMixedValuesAndTypes()
+        {
+            binder.Bind<IListItem>().ToValue(new ListItemA());
+            binder.Bind<IListItem>().To<ListItemB>();
+
+            var list1 = context.injectionBinder.GetInstance<List<IListItem>>();
+            var list2 = context.injectionBinder.GetInstance<List<IListItem>>();
+
+            Assert.AreNotEqual(list1, list2);
+
+            // Singleton
+            Assert.AreEqual(list1[0], list2[0]);
+
+            // New instance
+            Assert.AreNotEqual(list1[1], list2[1]);
+
+        }
+    }
+
+    public interface IListItem
+    {
+
+    }
+
+    public class ListItemA : IListItem
+    {
+
+    }
+    public class ListItemB: IListItem
+    {
+
+    }
+}

--- a/.tests/testPayloads/MockContext.cs
+++ b/.tests/testPayloads/MockContext.cs
@@ -12,6 +12,8 @@ using strange.extensions.dispatcher.eventdispatcher.impl;
 using strange.extensions.mediation.impl;
 using strange.extensions.sequencer.impl;
 using strange.extensions.dispatcher.api;
+using strange.extensions.listBind.api;
+using strange.extensions.listBind.impl;
 
 namespace strange.unittests
 {
@@ -31,6 +33,7 @@ namespace strange.unittests
 		/// A Binder that maps Events to Sequences
 		public ISequencer sequencer{get;set;}
 
+        public IListBinder listBinder { get; set; }
 		public IImplicitBinder implicitBinder { get; set; }
 
 		public MockContext() : base() {}
@@ -56,6 +59,7 @@ namespace strange.unittests
 			injectionBinder.Bind<IMediationBinder>().To<MediationBinder>().ToSingleton();
 			injectionBinder.Bind<ISequencer>().To<EventSequencer>().ToSingleton();
 			injectionBinder.Bind<IImplicitBinder>().To<ImplicitBinder>().ToSingleton();
+            injectionBinder.Bind<IListBinder>().To<ListBinder>().ToSingleton();
 		}
 
 		protected override void instantiateCoreComponents()
@@ -67,7 +71,7 @@ namespace strange.unittests
 			mediationBinder = injectionBinder.GetInstance<IMediationBinder>() as IMediationBinder;
 			sequencer = injectionBinder.GetInstance<ISequencer>() as ISequencer;
 			implicitBinder = injectionBinder.GetInstance<IImplicitBinder>() as IImplicitBinder;
-
+            listBinder = injectionBinder.GetInstance<IListBinder>() as IListBinder;
 			(dispatcher as ITriggerProvider).AddTriggerable(commandBinder as ITriggerable);
 			(dispatcher as ITriggerProvider).AddTriggerable(sequencer as ITriggerable);
 

--- a/extensions/context/impl/MVCSContext.cs
+++ b/extensions/context/impl/MVCSContext.cs
@@ -171,6 +171,8 @@ using strange.extensions.sequencer.api;
 using strange.extensions.sequencer.impl;
 using strange.framework.api;
 using strange.framework.impl;
+using strange.extensions.listBind.api;
+using strange.extensions.listBind.impl;
 
 namespace strange.extensions.context.impl
 {
@@ -187,6 +189,9 @@ namespace strange.extensions.context.impl
 
 		//Interprets implicit bindings
 		public IImplicitBinder implicitBinder { get; set; }
+
+        /// A Binder that allows binging similar binding to an injectable list.
+        public IListBinder listBinder { get; set; }
 
 		/// A Binder that maps Events to Sequences
 		public ISequencer sequencer{get;set;}
@@ -239,6 +244,7 @@ namespace strange.extensions.context.impl
 			injectionBinder.Bind<IMediationBinder>().To<MediationBinder>().ToSingleton();
 			injectionBinder.Bind<ISequencer>().To<EventSequencer>().ToSingleton();
 			injectionBinder.Bind<IImplicitBinder>().To<ImplicitBinder>().ToSingleton();
+            injectionBinder.Bind<IListBinder>().To<ListBinder>().ToSingleton();
 		}
 		
 		protected override void instantiateCoreComponents()
@@ -255,6 +261,7 @@ namespace strange.extensions.context.impl
 			mediationBinder = injectionBinder.GetInstance<IMediationBinder>() as IMediationBinder;
 			sequencer = injectionBinder.GetInstance<ISequencer>() as ISequencer;
 			implicitBinder = injectionBinder.GetInstance<IImplicitBinder>() as IImplicitBinder;
+            listBinder = injectionBinder.GetInstance<IListBinder>() as IListBinder;
 
 			(dispatcher as ITriggerProvider).AddTriggerable(commandBinder as ITriggerable);
 			(dispatcher as ITriggerProvider).AddTriggerable(sequencer as ITriggerable);

--- a/extensions/injector/api/IInjector.cs
+++ b/extensions/injector/api/IInjector.cs
@@ -42,6 +42,7 @@ using System;
 using System.Collections.Generic;
 using strange.extensions.reflector.api;
 using strange.framework.api;
+using strange.extensions.listBind.api;
 
 namespace strange.extensions.injector.api
 {
@@ -67,6 +68,8 @@ namespace strange.extensions.injector.api
 
 		/// Get/set an InjectionBinder.
 		IInjectionBinder binder{ get; set;}
+        /// Get/set an ListBinder.
+        IListBinder listBinder { get; set; }
 
 		/// Get/set a ReflectionBinder.
 		IReflectionBinder reflector{ get; set;}

--- a/extensions/injector/impl/Injector.cs
+++ b/extensions/injector/impl/Injector.cs
@@ -42,6 +42,8 @@ using System.Collections.Generic;
 using System.Reflection;
 using strange.extensions.injector.api;
 using strange.extensions.reflector.api;
+using System.Collections;
+using strange.extensions.listBind.api;
 
 namespace strange.extensions.injector.impl
 {
@@ -57,6 +59,7 @@ namespace strange.extensions.injector.impl
 
 		public IInjectorFactory factory{ get; set;}
 		public IInjectionBinder binder{ get; set;}
+        public IListBinder listBinder { get; set; }
 		public IReflectionBinder reflector{ get; set;}
 
 		public object Instantiate(IInjectionBinding binding)
@@ -146,6 +149,7 @@ namespace strange.extensions.injector.impl
 			{
 				target = performConstructorInjection(target, reflection);
 			}
+            performListInjection(target, reflection);
 			performSetterInjection(target, reflection);
 			postInject(target, reflection);
 			return target;
@@ -192,6 +196,41 @@ namespace strange.extensions.injector.impl
 			object constructedObj = constructor.Invoke (values);
 			return (constructedObj == null) ? target : constructedObj;
 		}
+
+        private void performListInjection(object target, IReflectedClass reflection)
+        {
+            if (!typeof(IList).IsAssignableFrom(target.GetType()))
+            {
+                return;
+            }
+            failIf(listBinder== null, "Attempt to instantiate a list when no list binder defined", InjectionExceptionType.NO_BINDER);
+            failIf(target == null, "Attempt to inject into a null list", InjectionExceptionType.NULL_TARGET);
+            failIf(reflection == null, "Attempt to inject without a reflection", InjectionExceptionType.NULL_REFLECTION);
+
+
+            Type[] listItemTypes = target.GetType().GetGenericArguments();
+            // Non-generic lists are not supported.
+            if (listItemTypes.Length == 0)
+            {
+                return;
+            }
+
+            IListBinding listBinding = listBinder.GetListBinding(listItemTypes[0]);
+            if (listBinding == null)
+            {
+                return;
+            }
+            IList list = (IList)target;
+            foreach (var binding in listBinding.Bindings)
+            {
+                object item = Instantiate(binding);
+                list.Add(item);
+            }
+           // IListBinding listBinding = binder.GetBinding(t, name);
+
+        }
+
+
 
 		private void performSetterInjection(object target, IReflectedClass reflection)
 		{

--- a/extensions/listBinding.meta
+++ b/extensions/listBinding.meta
@@ -1,0 +1,5 @@
+fileFormatVersion: 2
+guid: 65d3ed41e102b6e469ecc0af78a8e8e5
+folderAsset: yes
+DefaultImporter:
+  userData: 

--- a/extensions/listBinding/api.meta
+++ b/extensions/listBinding/api.meta
@@ -1,0 +1,5 @@
+fileFormatVersion: 2
+guid: 112226cfa11612841aa924b2f5a195da
+folderAsset: yes
+DefaultImporter:
+  userData: 

--- a/extensions/listBinding/api/IListBinder.cs
+++ b/extensions/listBinding/api/IListBinder.cs
@@ -1,0 +1,28 @@
+﻿/*
+ * Copyright 2013 ThirdMotion, Inc.
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *		Unless required by applicable law or agreed to in writing, software
+ *		distributed under the License is distributed on an "AS IS" BASIS,
+ *		WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *		See the License for the specific language governing permissions and
+ *		limitations under the License.
+ */
+
+
+using strange.framework.api;
+using System;
+
+namespace strange.extensions.listBind.api
+{
+    public interface IListBinder : IBinder
+    {
+        new IListBinding Bind<T>();
+        IListBinding GetListBinding(Type type);
+    }
+}

--- a/extensions/listBinding/api/IListBinder.cs.meta
+++ b/extensions/listBinding/api/IListBinder.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 349b6b5956b8afc459e8445836db5a89
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 

--- a/extensions/listBinding/api/IListBinding.cs
+++ b/extensions/listBinding/api/IListBinding.cs
@@ -1,0 +1,36 @@
+﻿/*
+ * Copyright 2013 ThirdMotion, Inc.
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *		Unless required by applicable law or agreed to in writing, software
+ *		distributed under the License is distributed on an "AS IS" BASIS,
+ *		WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *		See the License for the specific language governing permissions and
+ *		limitations under the License.
+ */
+
+
+using strange.extensions.injector.api;
+using strange.framework.api;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace strange.extensions.listBind.api
+{
+    public interface IListBinding : IBinding
+    {
+        new IInjectionBinding To<T>();
+        new IInjectionBinding ToValue(object o);
+
+        Type ListType { get; set; }
+
+        List<IInjectionBinding> Bindings { get; }
+    }
+}

--- a/extensions/listBinding/api/IListBinding.cs
+++ b/extensions/listBinding/api/IListBinding.cs
@@ -27,7 +27,7 @@ namespace strange.extensions.listBind.api
     public interface IListBinding : IBinding
     {
         new IInjectionBinding To<T>();
-        new IInjectionBinding ToValue(object o);
+        IInjectionBinding ToValue(object o);
 
         IListBinding ToSingleton();
 

--- a/extensions/listBinding/api/IListBinding.cs
+++ b/extensions/listBinding/api/IListBinding.cs
@@ -29,6 +29,8 @@ namespace strange.extensions.listBind.api
         new IInjectionBinding To<T>();
         new IInjectionBinding ToValue(object o);
 
+        new IListBinding ToSingleton();
+
         Type ListType { get; set; }
 
         List<IInjectionBinding> Bindings { get; }

--- a/extensions/listBinding/api/IListBinding.cs
+++ b/extensions/listBinding/api/IListBinding.cs
@@ -29,7 +29,7 @@ namespace strange.extensions.listBind.api
         new IInjectionBinding To<T>();
         new IInjectionBinding ToValue(object o);
 
-        new IListBinding ToSingleton();
+        IListBinding ToSingleton();
 
         Type ListType { get; set; }
 

--- a/extensions/listBinding/api/IListBinding.cs.meta
+++ b/extensions/listBinding/api/IListBinding.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5936a3e619fe5fc4bae3522b0818782c
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 

--- a/extensions/listBinding/impl.meta
+++ b/extensions/listBinding/impl.meta
@@ -1,0 +1,5 @@
+fileFormatVersion: 2
+guid: 85f2b828fb0597241a4c7869a00ab7ea
+folderAsset: yes
+DefaultImporter:
+  userData: 

--- a/extensions/listBinding/impl/ListBinder.cs
+++ b/extensions/listBinding/impl/ListBinder.cs
@@ -1,0 +1,78 @@
+﻿/*
+ * Copyright 2013 ThirdMotion, Inc.
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *		Unless required by applicable law or agreed to in writing, software
+ *		distributed under the License is distributed on an "AS IS" BASIS,
+ *		WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *		See the License for the specific language governing permissions and
+ *		limitations under the License.
+ */
+
+using strange.extensions.injector.api;
+using strange.extensions.listBind.api;
+using strange.framework.api;
+using strange.framework.impl;
+using System;
+using System.Collections.Generic;
+
+namespace strange.extensions.listBind.impl
+{
+    public class ListBinder : Binder, IListBinder
+    {
+        private readonly Dictionary<Type, IListBinding> listTypes = new Dictionary<Type, IListBinding>();
+        private IInjectionBinder _injectionBinder;
+
+        [Inject]
+        public IInjectionBinder injectionBinder 
+        {
+            get
+            {
+                return this._injectionBinder;
+            }
+            set
+            {
+                this._injectionBinder = value;
+                _injectionBinder.injector.listBinder = this;
+            }
+        }
+
+
+        public IListBinding GetListBinding(Type type)
+        {
+            if (!listTypes.ContainsKey(type))
+            {
+                return null;
+            }
+            return listTypes[type];
+        }
+
+        public override IBinding GetRawBinding()
+        {
+            return new ListBinding(resolver, _injectionBinder) as IBinding;
+        }
+
+        public new IListBinding Bind<T>()
+        {
+            IListBinding binding = null;
+            if (listTypes.ContainsKey(typeof(T)))
+            {
+                binding = listTypes[typeof(T)];   
+            }
+            else
+            {
+                binding = base.Bind<T>() as IListBinding;
+                binding.ListType = typeof(T);
+                listTypes[typeof(T)] = binding;
+                injectionBinder.Bind<IList<T>>().To<List<T>>();
+                injectionBinder.Bind<List<T>>().To<List<T>>();
+            }
+            return binding;
+        }
+    }
+}

--- a/extensions/listBinding/impl/ListBinder.cs
+++ b/extensions/listBinding/impl/ListBinder.cs
@@ -67,10 +67,9 @@ namespace strange.extensions.listBind.impl
             else
             {
                 binding = base.Bind<T>() as IListBinding;
-                binding.ListType = typeof(T);
+                binding.ListType = typeof(IList<T>);
                 listTypes[typeof(T)] = binding;
                 injectionBinder.Bind<IList<T>>().To<List<T>>();
-                injectionBinder.Bind<List<T>>().To<List<T>>();
             }
             return binding;
         }

--- a/extensions/listBinding/impl/ListBinder.cs.meta
+++ b/extensions/listBinding/impl/ListBinder.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1b3abc894a44f3d4882c05a0e36dfc45
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 

--- a/extensions/listBinding/impl/ListBinding.cs
+++ b/extensions/listBinding/impl/ListBinding.cs
@@ -1,0 +1,60 @@
+﻿/*
+ * Copyright 2013 ThirdMotion, Inc.
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *		Unless required by applicable law or agreed to in writing, software
+ *		distributed under the License is distributed on an "AS IS" BASIS,
+ *		WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *		See the License for the specific language governing permissions and
+ *		limitations under the License.
+ */
+
+using strange.extensions.injector.api;
+using strange.extensions.listBind.api;
+using strange.framework.api;
+using strange.framework.impl;
+using System;
+using System.Collections.Generic;
+
+namespace strange.extensions.listBind.impl
+{
+    public class ListBinding : Binding, IListBinding
+    {
+        private readonly List<IInjectionBinding> bindings = new List<IInjectionBinding>();
+
+        private readonly IInjectionBinder injectionBinder;
+
+        public ListBinding(Binder.BindingResolver resolver, IInjectionBinder injectionBinder)
+            : base(resolver)
+		{
+            this.injectionBinder = injectionBinder;
+		}
+
+        public Type ListType { get; set; }
+
+        public List<IInjectionBinding> Bindings { get { return this.bindings;  } }
+
+        public new IInjectionBinding To<T>()
+        {
+            var binding = injectionBinder.Bind(ListType).To<T>().ToName(typeof(T).ToString());
+            bindings.Add(binding);
+            //var binding = base.To<T>().ToName(typeof(T).ToString());
+            //this.bindings.Add(binding);
+            return binding;
+
+        }
+
+        public IInjectionBinding ToValue(object o)
+        {
+            var binding = injectionBinder.Bind(ListType).ToValue(o).ToName(o.ToString());
+            bindings.Add(binding);
+            return binding;
+        }
+
+    }
+}

--- a/extensions/listBinding/impl/ListBinding.cs
+++ b/extensions/listBinding/impl/ListBinding.cs
@@ -37,24 +37,42 @@ namespace strange.extensions.listBind.impl
 
         public Type ListType { get; set; }
 
+        public Type ListItemType 
+        {
+            get
+            {
+                return ListType.GetGenericArguments()[0];
+            }
+        }
+
         public List<IInjectionBinding> Bindings { get { return this.bindings;  } }
 
         public new IInjectionBinding To<T>()
         {
-            var binding = injectionBinder.Bind(ListType).To<T>().ToName(typeof(T).ToString());
+            var binding = injectionBinder.Bind(ListItemType).To<T>().ToName(typeof(T).ToString());
             bindings.Add(binding);
-            //var binding = base.To<T>().ToName(typeof(T).ToString());
-            //this.bindings.Add(binding);
             return binding;
 
         }
 
         public IInjectionBinding ToValue(object o)
         {
-            var binding = injectionBinder.Bind(ListType).ToValue(o).ToName(o.ToString());
+            var binding = injectionBinder.GetBinding(o.GetType(), o.ToString());
+            if (binding == null)
+            {
+                binding = injectionBinder.Bind(ListItemType).ToValue(o).ToName(o.ToString());
+            }
             bindings.Add(binding);
             return binding;
         }
 
+
+
+        public IListBinding ToSingleton()
+        {
+            var listBinding = injectionBinder.GetBinding(ListType);
+            listBinding.ToSingleton();
+            return this;
+        }
     }
 }

--- a/extensions/listBinding/impl/ListBinding.cs.meta
+++ b/extensions/listBinding/impl/ListBinding.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b5579fa83208d454f9a232c689e841cf
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 


### PR DESCRIPTION
List Binder that binds a values as an injectable list. 

Usage:
listBinder.Bind<IMyClass>().To<MyClass>();

[Inject]
public IList<IMyClass> myInstances;

Internally list binder uses injection binder to populate the list with instances. Expanded InjectionBinder with a dedicated method for instantiating list bindings (performListInjection)

See TestListBinder for reference

TODO named list bindings.
